### PR TITLE
v3o18: allow DELETE requests to reach this decision node

### DIFF
--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -739,7 +739,7 @@ module Make(IO:Cohttp.S.IO) = struct
       self#d "v3o18";
       match self#meth with
       (* The HTTP method could be POST if the request comes via v3o20 *)
-      | `OPTIONS | `DELETE | `PUT -> assert false
+      | `OPTIONS | `PUT -> assert false
       | `HEAD | `GET ->
         let _, to_content =
           match content_type with


### PR DESCRIPTION
v3o18 is in fact reachable for a DELETE request via m20, o20.
