### PR TITLE
Keep dependencies in sync with OPAM

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -1,18 +1,25 @@
 OASISFormat: 0.4
 Name:        webmachine
 Version:     0.1.0
-Synopsis:    Web Machine
+Synopsis:    A REST toolkit for OCaml
+Description: OCaml webmachine is a layer on top of cohttp that implements a
+  state-machine-based HTTP request processor.  It's particularly well-suited for
+  writing RESTful APIs.  As the name suggests, this is an OCaml port of the
+  webmachine project.
 Authors:     Spiros Eliopoulos <spiros@inhabitedytpe.com>
+Maintainers: Spiros Eliopoulos <spiros@inhabitedytpe.com>
+Homepage:    https://github.com/inhabitedtype/ocaml-webmachine
 Copyrights:  (C) 2015 Inhabited Type LLC
 License:     PROP
 Plugins:     META (0.4), DevFiles (0.4)
 BuildTools:  ocamlbuild
+OCamlVersion: >= 4.01
 
 Library webmachine
   Path:             lib
   InternalModules:  Wm_util
   Modules:          Webmachine
-  BuildDepends:     cohttp, re, re.str
+  BuildDepends:     cohttp, re (>= 1.3.0), re.str
 
 Document webmachine
   Title:                webmachine docs
@@ -47,3 +54,9 @@ Test test_dispatch
   Run$:             flag(tests)
   Command:          $test_dispatch
   WorkingDirectory: lib_test
+
+
+SourceRepository master
+  Type:     git
+  Location: https://github.com/inhabitedtype/ocaml-webmachine.git
+  Browser:  https://github.com/inhabitedtype/ocaml-webmachine


### PR DESCRIPTION
With these changes, your opam files may be automatically generated using [oasis2opam](https://github.com/ocaml/oasis2opam).