### PR TITLE
v3o20-fix: invert test in v3o20, and test response body

### DIFF
--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -809,9 +809,9 @@ module Make(IO:IO) = struct
 
     method v3o20 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3o20";
-      match body with
-      | `Empty -> self#v3o18
-      | _      -> self#respond ~status:`No_content ()
+      match rd.Rd.resp_body with
+      | `Empty -> self#respond ~status:`No_content ()
+      | _      -> self#v3o18
 
     method v3p3 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3p3";

--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ build-test: [
 ]
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
-  "cohttp"
+  "cohttp" {>= "0.9.11"}
   "ocamlfind" {build}
   "ounit" {test & >= "1.0.2"}
   "re" {>= "1.3.0"}


### PR DESCRIPTION
The previous code was checking the _request_ body and if it was not empty, returned 204. This decision node now does the correct thing, which is to check the response body and return a 204 if it is empty, and
proceed down the decision diagram otherwise.

Closes #22