### PR TITLE
is_authorized: support www-authenticate header

### DIFF
--- a/lib/webmachine.mli
+++ b/lib/webmachine.mli
@@ -116,7 +116,7 @@ module type S = sig
 
     method resource_exists : (bool, 'body) op
     method service_available : (bool, 'body) op
-    method is_authorized : (bool, 'body) op
+    method is_authorized : ([`Yes | `No of string], 'body) op
     method forbidden : (bool, 'body) op
     method malformed_request : (bool, 'body) op
     method uri_too_long : (bool, 'body) op

--- a/lib_test/test_logic.ml
+++ b/lib_test/test_logic.ml
@@ -82,7 +82,7 @@ class test_resource = object
 
   val _resource_exits = ref true
   val _service_available = ref true
-  val _is_authorized = ref true
+  val _is_authorized = ref `Yes
   val _forbidden = ref false
   val _malformed_request = ref false
   val _uri_too_long = ref false


### PR DESCRIPTION
A request can either be authorized, or not authorized. If it's not authorized, then it the resource is required to suggest a method by which the client may authenticate.

A garbage header value is probably ok here, given that authentication on the web's a bit broken.