### PR TITLE
auth: Support typical auth schemes for is_authorized return type

### DIFF
--- a/lib/webmachine.mli
+++ b/lib/webmachine.mli
@@ -107,6 +107,12 @@ module type S = sig
   type 'body provider = ('body, 'body) op
   type 'body acceptor = (bool, 'body) op
 
+  type auth =
+    [ `Authorized
+    | `Basic of string
+    | `Redirect of Uri.t
+    ]
+
   val continue : 'a -> ('a, 'body) op
   (** [continue a rd] is equivalent to [IO.return (Ok x, rd)] *)
 
@@ -121,7 +127,7 @@ module type S = sig
 
     method resource_exists : (bool, 'body) op
     method service_available : (bool, 'body) op
-    method is_authorized : ([`Yes | `No of string], 'body) op
+    method is_authorized : (auth, 'body) op
     method forbidden : (bool, 'body) op
     method malformed_request : (bool, 'body) op
     method uri_too_long : (bool, 'body) op

--- a/lib_test/test_logic.ml
+++ b/lib_test/test_logic.ml
@@ -86,7 +86,7 @@ class test_resource = object
 
   val _resource_exits = ref true
   val _service_available = ref true
-  val _is_authorized = ref `Yes
+  val _is_authorized = ref `Authorized
   val _forbidden = ref false
   val _malformed_request = ref false
   val _uri_too_long = ref false


### PR DESCRIPTION
The Erlang implementation only allows a resource to indicate that the request is authorized, or to issue a authentication challenge for the Basic authorization scheme, given a realm. This implementation supports those two modes, as well as an additional one. A resource may specify a URI that the user-agent should visit where further authentication instructions will be present.