### PR TITLE
Add initial support for PATCH.

### DIFF
--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -118,6 +118,8 @@ module type S = sig
     method virtual content_types_provided : ((string * ('body provider)) list, 'body) op
     method virtual content_types_accepted : ((string * ('body acceptor)) list, 'body) op
 
+    method virtual patch_content_types_accepted : ((string * ('body acceptor)) list, 'body) op
+
     method resource_exists : (bool, 'body) op
     method service_available : (bool, 'body) op
     method is_authorized : (auth, 'body) op
@@ -206,6 +208,8 @@ module Make(IO:IO) = struct
 
     method virtual content_types_provided : ((string * ('body provider)) list, 'body) op
     method virtual content_types_accepted : ((string * ('body acceptor)) list, 'body) op
+
+    method virtual patch_content_types_accepted : ((string * ('body acceptor)) list, 'body) op
 
     method resource_exists (rd:'body Rd.t) : (bool result * 'body Rd.t) IO.t =
       continue true rd
@@ -411,6 +415,23 @@ module Make(IO:IO) = struct
         | Some type_ -> Some type_
       in
       self#run_op resource#content_types_accepted
+      >>~ fun provided ->
+        match Util.MediaType.match_header provided header with
+        | None                -> self#halt 415
+        | Some(_, of_content) ->
+          self#run_op of_content
+          >>~ function complete ->
+            if complete then
+              self#encode_body;
+            k complete
+
+    method private patch_accept_helper k =
+      let header =
+        match self#get_request_header "content-type" with
+        | None       -> Some "application/octet-stream"
+        | Some type_ -> Some type_
+      in
+      self#run_op resource#patch_content_types_accepted
       >>~ fun provided ->
         match Util.MediaType.match_header provided header with
         | None                -> self#halt 415
@@ -818,8 +839,15 @@ module Make(IO:IO) = struct
       self#d "v3o16";
       match self#meth with
       | `OPTIONS | `DELETE | `POST -> assert false
-      | `PUT -> self#v3o14
-      | _    -> self#v3o18
+      | `PUT   -> self#v3o14
+      | `PATCH -> self#v3o17
+      | _      -> self#v3o18
+
+    method v3o17 : (Code.status_code * Header.t * 'body) IO.t =
+      self#d "v3o17";
+      match self#meth with
+      | `PATCH -> self#patch_accept_helper (fun _ -> self#v3o20)
+      | _ -> self#v3o18
 
     method v3o18 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3o18";

--- a/lib/webmachine.mli
+++ b/lib/webmachine.mli
@@ -124,6 +124,7 @@ module type S = sig
 
     method virtual content_types_provided : ((string * ('body provider)) list, 'body) op
     method virtual content_types_accepted : ((string * ('body acceptor)) list, 'body) op
+    method virtual patch_content_types_accepted : ((string * ('body acceptor)) list, 'body) op
 
     method resource_exists : (bool, 'body) op
     method service_available : (bool, 'body) op

--- a/lib_test/test_dispatch.ml
+++ b/lib_test/test_dispatch.ml
@@ -61,6 +61,9 @@ class base_path str = object
   method content_types_accepted rd =
     Webmachine.continue [] rd
 
+  method patch_content_types_accepted rd =
+    Webmachine.continue [] rd
+
   method allowed_methods rd =
     Webmachine.continue [`GET] rd
 end
@@ -79,6 +82,9 @@ class param_path key = object
   method content_types_accepted rd =
     Webmachine.continue [] rd
 
+  method patch_content_types_accepted rd =
+    Webmachine.continue [] rd
+
   method allowed_methods rd =
     Webmachine.continue [`GET] rd
 end
@@ -94,6 +100,9 @@ class disp_path = object
     ] rd
 
   method content_types_accepted rd =
+    Webmachine.continue [] rd
+
+  method patch_content_types_accepted rd =
     Webmachine.continue [] rd
 
   method allowed_methods rd =

--- a/lib_test/test_logic.ml
+++ b/lib_test/test_logic.ml
@@ -52,7 +52,7 @@ open Cohttp
 
 let http_1_0_methods = [`GET; `POST; `HEAD]
 let http_1_1_methods =
-  [`GET; `HEAD; `POST; `PUT; `DELETE; `Other "TRACE"; `Other "CONNECT"; `OPTIONS]
+  [`GET; `HEAD; `PATCH; `POST; `PUT; `DELETE; `Other "TRACE"; `Other "CONNECT"; `OPTIONS]
 let default_allowed_methods = [`GET; `HEAD; `PUT]
 
 let to_html rd = Webmachine.continue (`String "<html><body>Foo</body></html>") rd
@@ -73,16 +73,21 @@ class test_resource = object
 
   val _content_types_provided = ref ["text/html", to_html]
   val _content_types_accepted = ref []
+  val _patch_content_types_accepted = ref []
 
   method content_types_provided rd =
     Webmachine.continue !_content_types_provided rd
   method content_types_accepted rd =
     Webmachine.continue !_content_types_accepted rd
+  method patch_content_types_accepted rd =
+    Webmachine.continue !_patch_content_types_accepted rd
 
   method set_content_types_provided v =
     _content_types_provided := v
   method set_content_types_accepted v =
     _content_types_accepted := v
+  method set_patch_content_types_accepted v =
+    _patch_content_types_accepted := v
 
   val _resource_exits = ref true
   val _service_available = ref true
@@ -95,7 +100,7 @@ class test_resource = object
   val _valid_entity_length = ref true
   val _options = ref []
   val _allowed_methods = ref [`GET; `HEAD]
-  val _known_methods = ref [`GET; `HEAD; `POST; `PUT; `DELETE; `Other "TRACE"; `Other "CONNECT"; `OPTIONS]
+  val _known_methods = ref [`GET; `HEAD; `PATCH; `POST; `PUT; `DELETE; `Other "TRACE"; `Other "CONNECT"; `OPTIONS]
   val _delete_resource = ref false
   val _delete_completed = ref true
   val _process_post = ref false


### PR DESCRIPTION
I think this covers the parts of the [webmachine diagram](https://raw.githubusercontent.com/wiki/webmachine/webmachine/images/http-headers-status-v3.png) that are implemented here.It seems like the decision nodes m5 and m7 aren't implemented, which is where I'd put the rest of the implementation.

Happy to write some tests and/or examples if this is something you'd like supported. 

The relevant RFC -> https://tools.ietf.org/html/rfc5789