### PR TITLE
Example code: Fix typos in comments; link to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will be better-documented in the future.
 
 ### Examples
 
-To build the examples in the `examples/` subdirectory, reconfigure the build
+To build the examples in the [`examples/`][examples_dir] subdirectory, reconfigure the build
 process and recompile:
 
 ```bash
@@ -40,7 +40,7 @@ make clean && make
 ```
 
 [diagram]: https://raw.githubusercontent.com/webmachine/webmachine/develop/docs/http-headers-status-v3.png
-
+[examples_dir]: examples/
 
 ## Development
 

--- a/examples/crud_lwt.ml
+++ b/examples/crud_lwt.ml
@@ -16,7 +16,7 @@
 
       [DEBUG_PATH= ./crud_lwt.native]
 
-    Here are some sample CURL command to test on a running server:
+    Here are some sample CURL commands to test on a running server:
 
       - Get a complete list of items:
         [curl -i -w "\n" -X GET http://localhost:8080/items]
@@ -192,7 +192,7 @@ let main () =
     ("/items", fun () -> new items db) ;
     ("/item/:id", fun () -> new item db) ;
   ] in
-  let callback (ch,conn) request body =
+  let callback (ch, conn) request body =
     let open Cohttp in
     (* Perform route dispatch. If [None] is returned, then the URI path did not
      * match any of the route patterns. In this case the server should return a
@@ -224,7 +224,7 @@ let main () =
       Server.respond ~headers ~body ~status ()
   in
   (* create the server and handle requests with the function defined above *)
-  let conn_closed (ch,conn) =
+  let conn_closed (ch, conn) =
     Printf.printf "connection %s closed\n%!"
       (Sexplib.Sexp.to_string_hum (Conduit_lwt_unix.sexp_of_flow ch))
   in

--- a/examples/hello_async.ml
+++ b/examples/hello_async.ml
@@ -14,7 +14,7 @@ module Wm = struct
 end
 
 (* Create a new class that inherits from [Wm.resource] and provides
- * implementations for its two virutal methods, and overrides some of its default methods.
+ * implementations for its two virtual methods, and overrides some of its default methods.
  *)
 class hello = object(self)
   inherit [Body.t] Wm.resource
@@ -51,7 +51,7 @@ class hello = object(self)
   (* Since only GET requests are allowed, there's no need to provide handlers
    * for requests containing certain content types. This method will never be
    * called, but it's necessary to provide an implementation since it's
-   * [virtual] in the [Wm.resouce] virutal class. *)
+   * [virtual] in the [Wm.resource] virtual class. *)
   method content_types_accepted rd =
     Wm.continue [] rd
 

--- a/examples/hello_lwt.ml
+++ b/examples/hello_lwt.ml
@@ -51,7 +51,7 @@ class hello = object(self)
   (* Since only GET requests are allowed, there's no need to provide handlers
    * for requests containing certain content types. This method will never be
    * called, but it's necessary to provide an implementation since it's
-   * [virtual] in the [Wm.resouce] virutal class. *)
+   * [virtual] in the [Wm.resource] virtual class. *)
   method content_types_accepted rd =
     Wm.continue [] rd
 


### PR DESCRIPTION
This PR copy-edits a comment in the example code and links to the `examples/` folder in the README's Getting Started section.

(PS: I heard about this project from @hannesm.)