### PR TITLE
fix for new cohttp

### DIFF
--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -46,7 +46,7 @@ module Rd = struct
   type 'body t =
     { version       : Code.version
     ; meth          : Code.meth
-    ; uri           : Uri.t
+    ; resource      : string
     ; req_headers   : Header.t
     ; req_body      : 'body
     ; resp_headers  : Header.t
@@ -62,7 +62,7 @@ module Rd = struct
       ?(resp_headers=Header.init ()) ?(resp_body=`Empty) ?(resp_redirect=false)
       ?(req_body=`Empty) ~request ()
     =
-    { uri     = request.Request.uri
+    { resource = request.Request.resource
     ; version = request.Request.version
     ; meth    = request.Request.meth
     ; req_headers = request.Request.headers

--- a/lib/webmachine.mli
+++ b/lib/webmachine.mli
@@ -63,7 +63,7 @@ module Rd : sig
   type 'body t =
     { version       : Code.version
     ; meth          : Code.meth
-    ; uri           : Uri.t
+    ; resource      : string
     ; req_headers   : Header.t
     ; req_body      : 'body
     ; resp_headers  : Header.t

--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "webmachine"
-version: "0.3.1"
+version: "0.3.3"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
@@ -23,7 +23,7 @@ build-test: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "calendar" {>= "2.03.2"}
-  "cohttp" {>= "0.12.0" & < "0.21.0"}
+  "cohttp" {>= "0.12.0"}
   "dispatch" {>= "0.3.0"}
   "ocamlfind" {build}
   "ounit" {test & >= "1.0.2"}

--- a/opam/opam
+++ b/opam/opam
@@ -23,7 +23,7 @@ build-test: [
 build-doc: [ "ocaml" "setup.ml" "-doc" ]
 depends: [
   "calendar" {>= "2.03.2"}
-  "cohttp" {>= "0.12.0"}
+  "cohttp" {>= "0.21.0"}
   "dispatch" {>= "0.3.0"}
   "ocamlfind" {build}
   "ounit" {test & >= "1.0.2"}


### PR DESCRIPTION
It would be good if you could release 0.3.3 with this.
I need it because `irmin` uses it, and it forces me to use an older version of `cohttp`.
Thanks!