### PR TITLE
Remove the dependency on calendar and disable the tests for those decision points.

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -22,7 +22,6 @@ Flag examples
 Library webmachine
   Path:             lib
   BuildDepends:
-    calendar        (>= 2.03.2),
     cohttp          (>= 0.21.0),
     dispatch        (>= 0.3.0),
     re              (>= 1.3.0),
@@ -85,7 +84,6 @@ Executable test_logic
   CompiledObject:   best
   Install:          false
   BuildDepends:
-    calendar,
     cohttp,
     oUnit           (>= 1.0.2),
     webmachine
@@ -97,7 +95,6 @@ Executable test_dispatch
   CompiledObject:   best
   Install:          false
   BuildDepends:
-    calendar,
     cohttp,
     oUnit           (>= 1.0.2),
     webmachine

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,4 +3,4 @@
  ((name webmachine)
   (public_name webmachine)
   (wrapped false)
-  (libraries (calendar cohttp dispatch re re.str uri))))
+  (libraries (cohttp dispatch re re.str uri))))

--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -698,9 +698,8 @@ module Make(IO:IO) = struct
       match d with
       | None -> self#v3i12
       | Some d' ->
-         match (Util.Date.parse_rfc1123_date d') with
-         | None -> self#v3i12
-         | Some _ -> self#v3h12
+         (* all dates are currently unparseable *)
+         self#v3i12
 
     method v3h12 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3h12";
@@ -710,9 +709,8 @@ module Make(IO:IO) = struct
         >>~ fun l_mod ->
         match (u_mod, l_mod) with
         | (Some u_mod', Some l_mod') ->
-           (match (Util.Date.parse_rfc1123_date_exn l_mod') > (Util.Date.parse_rfc1123_date_exn u_mod') with
-           | false -> self#v3i12
-           | true -> self#halt 412)
+           (* all dates are currently unparseable *)
+           self#v3i12
         | (_, _) -> self#v3i12
       with
         Invalid_argument _ -> self#halt 412
@@ -803,21 +801,14 @@ module Make(IO:IO) = struct
       match (self#get_request_header "if-modified-since") with
       | None -> self#v3m16
       | Some date ->
-         match (Util.Date.parse_rfc1123_date date) with
-         | Some _ -> self#v3l15
-         | None ->  self#v3m16
+         (* all dates are currently unparseable *)
+         self#v3m16
 
     method v3l15 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3l15";
-      let now = CalendarLib.Time.now() in
-      match (self#get_request_header "if-modified-since") with
-      | None -> self#v3l17
-      | Some date ->
-         match (Util.Date.parse_rfc1123_date date) with
-         | None -> self#v3l17
-         | Some d -> match (d > now) with
-                     | true -> self#v3m16
-                     | false -> self#v3l17
+      (* we are timeless, which presents a problem here *)
+      (* act as though we always need to server the resource anew *)
+      self#v3m16
 
     method v3l17 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3l17";
@@ -827,9 +818,8 @@ module Make(IO:IO) = struct
         >>~ fun l_mod ->
             match (u_mod, l_mod) with
             | (Some l_mod', Some u_mod') ->
-               (match (Util.Date.parse_rfc1123_date_exn l_mod') > (Util.Date.parse_rfc1123_date_exn u_mod') with
-                | true -> self#v3m16
-                | false -> self#halt 304)
+               (* all dates are currently unparseable *)
+               self#v3m16
             | (_, _) -> self#halt 304
       with
         Invalid_argument _ -> self#halt 304

--- a/lib/wm_util.ml
+++ b/lib/wm_util.ml
@@ -110,14 +110,3 @@ module MediaType = struct
     in
     loop ranges
 end
-
-module Date = struct
-  open CalendarLib
-
-  let parse_rfc1123_date_exn s =
-    Printer.Time.from_fstring "%a, %d %b %Y %H:%M:%S GMT" s
-
-  let parse_rfc1123_date s =
-    try (Some (parse_rfc1123_date_exn s)) with
-    | Invalid_argument _ -> None
-end

--- a/lib_test/test_logic.ml
+++ b/lib_test/test_logic.ml
@@ -46,18 +46,6 @@ module Webmachine = struct
   include Webmachine.Make(Id)
 end
 
-(* TODO pull in from wm_util.ml rather than copy pasta *)
-module Date = struct
-  open CalendarLib
-
-  let parse_rfc1123_date_exn s =
-    Printer.Time.from_fstring "%a, %d %b %Y %H:%M:%S GMT" s
-
-  let parse_rfc1123_date s =
-    try (Some (parse_rfc1123_date_exn s)) with
-    | Invalid_argument _ -> None
-end
-
 let run = Id.run
 
 open Cohttp
@@ -702,18 +690,18 @@ let precond_fail_g11 () =
   assert_status ~msg:"412 result via G11" result 412;
 ;;
 
-let precond_fail_h12 () =
-  let ten_am = "Wed, 20 Feb 2013 10:00:00 GMT" in
-  let five_pm = "Wed, 20 Feb 2013 17:00:00 GMT" in
-  let headers = Header.of_list [("If-Unmodified-Since", ten_am)] in
-  let result = with_test_resource' begin fun resource ->
-    resource#set_allowed_methods default_allowed_methods;
-    resource#set_last_modified (Some five_pm);
-    Request.make ~headers ~meth:`GET Uri.(of_string "/"), `String "foo"
-  end in
-  assert_path ~msg:"412 result via h12, i13, i12, h10, h11" result Path.to_h12_no_acpthead;
-  assert_status ~msg:"412 result via h12, i13, i12, h10, h11" result 412;
-;;
+(* let precond_fail_h12 () = *)
+(*   let ten_am = "Wed, 20 Feb 2013 10:00:00 GMT" in *)
+(*   let five_pm = "Wed, 20 Feb 2013 17:00:00 GMT" in *)
+(*   let headers = Header.of_list [("If-Unmodified-Since", ten_am)] in *)
+(*   let result = with_test_resource' begin fun resource -> *)
+(*     resource#set_allowed_methods default_allowed_methods; *)
+(*     resource#set_last_modified (Some five_pm); *)
+(*     Request.make ~headers ~meth:`GET Uri.(of_string "/"), `String "foo" *)
+(*   end in *)
+(*   assert_path ~msg:"412 result via h12, i13, i12, h10, h11" result Path.to_h12_no_acpthead; *)
+(*   assert_status ~msg:"412 result via h12, i13, i12, h10, h11" result 412; *)
+(* ;; *)
 
 
 let precond_fail_j18 () =
@@ -742,21 +730,21 @@ let precond_fail_j18_via_k13 () =
   assert_status ~msg:"412 result via J18 via K13 via H11 via G11" result 412;
 ;;
 
-let precond_fail_j18_via_h12 () =
-  let ten_am =  "Wed, 20 Feb 2013 10:00:00 GMT" in
-  let five_pm = "Wed, 20 Feb 2013 17:00:00 GMT" in
-  let headers = Header.of_list [("If-Match", "*");
-                                ("If-None-Match", "*");
-                                ("If-Unmodified-Since", five_pm);
-                                ("Content-Type", "text/plain")] in
-  let result = with_test_resource' begin fun resource ->
-    resource#set_last_modified (Some ten_am);
-    resource#set_allowed_methods default_allowed_methods;
-    Request.make ~headers ~meth:`PUT Uri.(of_string "/"), `String "foo"
-  end in
-  assert_path ~msg:"412 result via J18 via I13 via I12 via H12" result Path.to_j18_no_acpthead_3;
-  assert_status ~msg:"412 result via J18 via I13 via I12 via H12" result 412;
-;;
+(* let precond_fail_j18_via_h12 () = *)
+(*   let ten_am =  "Wed, 20 Feb 2013 10:00:00 GMT" in *)
+(*   let five_pm = "Wed, 20 Feb 2013 17:00:00 GMT" in *)
+(*   let headers = Header.of_list [("If-Match", "*"); *)
+(*                                 ("If-None-Match", "*"); *)
+(*                                 ("If-Unmodified-Since", five_pm); *)
+(*                                 ("Content-Type", "text/plain")] in *)
+(*   let result = with_test_resource' begin fun resource -> *)
+(*     resource#set_last_modified (Some ten_am); *)
+(*     resource#set_allowed_methods default_allowed_methods; *)
+(*     Request.make ~headers ~meth:`PUT Uri.(of_string "/"), `String "foo" *)
+(*   end in *)
+(*   assert_path ~msg:"412 result via J18 via I13 via I12 via H12" result Path.to_j18_no_acpthead_3; *)
+(*   assert_status ~msg:"412 result via J18 via I13 via I12 via H12" result 412; *)
+(* ;; *)
 
 let content_valid () =
   let headers = Header.of_list [("Content-Type", "text/plain")] in
@@ -1003,18 +991,18 @@ not_modified_j18_via_h12() ->
     ok.
 *)
 
-let not_modified_l17 () =
-  let first_day_of_last_year = "Tue, 01 Jan 2015 00:00:00 GMT" in
-  let first_day_of_next_year = "Sun, 01 Jan 2017 00:00:00 GMT" in
-  let headers = Header.of_list [("If-Modified-Since", first_day_of_last_year)] in
-  let result = with_test_resource begin fun resource ->
-    resource#set_last_modified (Some first_day_of_last_year);
-    resource#set_expires (Some first_day_of_next_year);
-    Request.make ~headers ~meth:`GET Uri.(of_string "/foo");
-  end in
-  assert_path ~msg:"304 via l17" result Path.to_l17_no_acpthead;
-  assert_status ~msg:"304 via l17" result 304;
-;;
+(* let not_modified_l17 () = *)
+(*   let first_day_of_last_year = "Tue, 01 Jan 2015 00:00:00 GMT" in *)
+(*   let first_day_of_next_year = "Sun, 01 Jan 2017 00:00:00 GMT" in *)
+(*   let headers = Header.of_list [("If-Modified-Since", first_day_of_last_year)] in *)
+(*   let result = with_test_resource begin fun resource -> *)
+(*     resource#set_last_modified (Some first_day_of_last_year); *)
+(*     resource#set_expires (Some first_day_of_next_year); *)
+(*     Request.make ~headers ~meth:`GET Uri.(of_string "/foo"); *)
+(*   end in *)
+(*   assert_path ~msg:"304 via l17" result Path.to_l17_no_acpthead; *)
+(*   assert_status ~msg:"304 via l17" result 304; *)
+(* ;; *)
 
 (*
 
@@ -1446,10 +1434,10 @@ let _ =
     "not_acceptable_f7_e6_d5_c4" >:: not_acceptable_f7_e6_d5_c4;
     "precond_fail_no_resource" >:: precond_fail_no_resource;
     "precond_fail_g11" >:: precond_fail_g11;
-    "precond_fail_h12" >:: precond_fail_h12;
+    (* "precond_fail_h12" >:: precond_fail_h12; *)
     "precond_fail_j18" >:: precond_fail_j18;
     "precond_fail_j18_via_k13" >:: precond_fail_j18_via_k13;
-    "precond_fail_j18_via_h12" >:: precond_fail_j18_via_h12;
+    (* "precond_fail_j18_via_h12" >:: precond_fail_j18_via_h12; *)
     "content_valid" >:: content_valid;
     "authorized_b8" >:: authorized_b8;
     "forbidden_b7" >:: forbidden_b7;
@@ -1457,7 +1445,7 @@ let _ =
     "variances_o18" >:: variances_o18;
     "variances_o18_2" >:: variances_o18_2;
     "multiple_choices_o18" >:: multiple_choices_o18;
-    "not_modified_l17" >:: not_modified_l17;
+    (* "not_modified_l17" >:: not_modified_l17; *)
     "create_p11_put" >:: create_p11_put
   ] in
   let suite = (Printf.sprintf "test logic") >::: tests in

--- a/webmachine.opam
+++ b/webmachine.opam
@@ -13,7 +13,6 @@ build-test: [
   ["jbuilder" "runtest" "-p" name]
 ]
 depends: [
-  "calendar" {>= "2.03.2"}
   "cohttp" {>= "0.21.0"}
   "dispatch" {>= "0.3.0"}
   "jbuilder" {build & >= "1.0+beta10"}


### PR DESCRIPTION
Some of the decision points relied on date parsing and comparison, those have been disabled temporarily while an independent date parsing module is built.

Fixes this issue https://github.com/inhabitedtype/ocaml-webmachine/issues/73 by removing the `calendar` dependency thanks to @yomimono for the pointers.

@seliopou this breaks a couple of tests unfortunately. 