### PR TITLE
accept: Don't crash on parsing errors

### DIFF
--- a/lib/wm_util.ml
+++ b/lib/wm_util.ml
@@ -103,7 +103,7 @@ module MediaType = struct
     | MediaType (type_', subtype') -> type_' = type_ && subtype' = subtype
 
   let match_header provided header =
-    let ranges = Accept.(media_ranges header |> qsort) in
+    let ranges = try Accept.(media_ranges header |> qsort) with Parsing.Parse_error -> [] in
     let rec loop = function
       | [] -> None
       | r::rs -> try Some(List.find (media_match r) provided) with Not_found -> loop rs


### PR DESCRIPTION
Cohttp.Accept.media_ranges raises exceptions when it can't parse the `Accept` header. Notably, whenever the format isn't: `(token)+/(token)+`, it raises an exception. Since we weren't capturing it, it went on to crash the server.

This patch makes it treat any parsing exception in the `Accept` header as if it asked for an unacceptable header.

For example, previously, sending 'Accept: bogus/bogus' would return 406, but 'Accept: bogus' would crash the server. Now both return 406.

I would have implemented a test for it, but comparing with Erlang tests, it seems they don't check for badly formatted headers. I don't know how close we want to keep with them, so I don't know where to place this test :) But my test application worked with this change.

Fixes #82.