### PR TITLE
Remove CalendarLib dependency

### DIFF
--- a/examples/crud_lwt.ml
+++ b/examples/crud_lwt.ml
@@ -88,7 +88,10 @@ end
  * access request-related information. *)
 module Wm = struct
   module Rd = Webmachine.Rd
-  include Webmachine.Make(Cohttp_lwt_unix__Io)
+  module UnixClock = struct
+    let now = fun () -> int_of_float @@ Unix.gettimeofday ()
+  end
+  include Webmachine.Make(Cohttp_lwt_unix__Io)(UnixClock)
 end
 
 (** A resource for querying all the items in the database via GET and creating

--- a/examples/hello_async.ml
+++ b/examples/hello_async.ml
@@ -9,7 +9,10 @@ open Cohttp_async
  * information. *)
 module Wm = struct
   module Rd = Webmachine.Rd
-  include Webmachine.Make(Cohttp_async.Io)
+  module UnixClock = struct
+    let now = fun () -> int_of_float @@ Unix.gettimeofday ()
+  end
+  include Webmachine.Make(Cohttp_async.Io)(UnixClock)
 end
 
 (* Create a new class that inherits from [Wm.resource] and provides

--- a/examples/hello_lwt.ml
+++ b/examples/hello_lwt.ml
@@ -8,7 +8,10 @@ open Cohttp_lwt_unix
  * access request-related information. *)
 module Wm = struct
   module Rd = Webmachine.Rd
-  include Webmachine.Make(Cohttp_lwt_unix__Io)
+  module UnixClock = struct
+    let now = fun () -> int_of_float @@ Unix.gettimeofday ()
+  end
+  include Webmachine.Make(Cohttp_lwt_unix__Io)(UnixClock)
 end
 
 (* Create a new class that inherits from [Wm.resource] and provides

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name        webmachine)
   (public_name webmachine)
-  (libraries   (calendar cohttp dispatch re re.str uri))))
+  (libraries   (cohttp dispatch re re.str uri ptime))))

--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -171,7 +171,11 @@ end
 let default_variances =
   [ "Accept"; "Accept-Encoding"; "Accept-Charset"; "Accept-Language"]
 
-module Make(IO:IO) = struct
+module type CLOCK = sig
+  val now : unit -> int
+end
+
+module Make(IO:IO)(Clock:CLOCK) = struct
   type +'a io = 'a IO.t
 
   open IO
@@ -809,7 +813,7 @@ module Make(IO:IO) = struct
 
     method v3l15 : (Code.status_code * Header.t * 'body) IO.t =
       self#d "v3l15";
-      let now = CalendarLib.Time.now() in
+      let now = Clock.now () in
       match (self#get_request_header "if-modified-since") with
       | None -> self#v3l17
       | Some date ->

--- a/lib/wm_util.ml
+++ b/lib/wm_util.ml
@@ -112,10 +112,42 @@ module MediaType = struct
 end
 
 module Date = struct
-  open CalendarLib
-
   let parse_rfc1123_date_exn s =
-    Printer.Time.from_fstring "%a, %d %b %Y %H:%M:%S GMT" s
+    try Scanf.sscanf s "%3s, %d %s %4d %d:%d:%d %s" (
+      fun _wday mday mon year hour min sec tz ->
+        let months = [
+          "Jan", 1; "Feb", 2; "Mar", 3; "Apr", 4; "May", 5; "Jun", 6;
+          "Jul", 7; "Aug", 8; "Sep", 9; "Oct", 10; "Nov", 11; "Dec", 12
+        ] in
+        let parse_tz = function
+          | "" | "Z" | "GMT" | "UTC" | "UT" -> 0
+          | "PST" -> -480
+          | "MST" | "PDT" -> -420
+          | "CST" | "MDT" -> -360
+          | "EST" | "CDT" -> -300
+          | "EDT" -> -240
+          | s -> Scanf.sscanf s "%c%02d%_[:]%02d" (fun sign hour min ->
+              min + hour * (if sign = '-' then -60 else 60))
+        in
+        let mon = List.assoc mon months in
+        let year =
+          if year < 50 then year + 2000
+          else if year < 1000 then year + 1900
+          else year
+        in
+        let date = (year, mon, mday) in
+        let time = ((hour, min, sec), (parse_tz tz)*60) in
+        let ptime = Ptime.of_date_time (date, time) in
+        match ptime with
+          | None -> raise @@ Invalid_argument "Invalid date string"
+          | Some date ->
+        match Ptime.(Span.to_int_s (to_span date)) with
+          | None -> raise @@ Invalid_argument "Invalid date string"
+          | Some t -> t
+    )
+    with
+      | Scanf.Scan_failure e -> raise @@ Invalid_argument e
+      | Not_found -> raise @@ Invalid_argument "Invalid date string"
 
   let parse_rfc1123_date s =
     try (Some (parse_rfc1123_date_exn s)) with

--- a/lib_test/test_dispatch.ml
+++ b/lib_test/test_dispatch.ml
@@ -40,9 +40,13 @@ module Id = struct
   let run (Id a) = a
 end
 
+module ClockMock = struct
+  let now = fun () -> 1526322704
+end
+
 module Webmachine = struct
   module Rd = Webmachine.Rd
-  include Webmachine.Make(Id)
+  include Webmachine.Make(Id)(ClockMock)
 end
 
 let run = Id.run

--- a/lib_test/test_logic.ml
+++ b/lib_test/test_logic.ml
@@ -41,21 +41,13 @@ module Id = struct
 
 end
 
-module Webmachine = struct
-  module Rd = Webmachine.Rd
-  include Webmachine.Make(Id)
+module ClockMock = struct
+  let now = fun () -> 1526322704
 end
 
-(* TODO pull in from wm_util.ml rather than copy pasta *)
-module Date = struct
-  open CalendarLib
-
-  let parse_rfc1123_date_exn s =
-    Printer.Time.from_fstring "%a, %d %b %Y %H:%M:%S GMT" s
-
-  let parse_rfc1123_date s =
-    try (Some (parse_rfc1123_date_exn s)) with
-    | Invalid_argument _ -> None
+module Webmachine = struct
+  module Rd = Webmachine.Rd
+  include Webmachine.Make(Id)(ClockMock)
 end
 
 let run = Id.run

--- a/webmachine.opam
+++ b/webmachine.opam
@@ -13,7 +13,7 @@ build-test: [
   ["jbuilder" "runtest" "-p" name]
 ]
 depends: [
-  "calendar" {>= "2.03.2"}
+  "ptime" {>= "0.8.0"}
   "cohttp" {>= "1.0.0"}
   "dispatch" {>= "0.3.0"}
   "jbuilder" {build & >= "1.0+beta10"}


### PR DESCRIPTION
For timestamp processing in HTTP headers so far the calendar module
has been used, which depends on unix.  This change implements a
simple RFC1123/RFC5322 parser and allows different clock sources to
be used.  Therefore a CLOCK module must be defined, that contains a
function "now" that returns the current time as a Ptime.t value.  The
Make functor now takes an additional Clock parameter for this module.
Examples for POSIX or MirageOS clocks are provided.

Closes #73
Closes #79
