### PR TITLE
wrapped: make webmachine a "wrapped" jbuilder library

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,6 +1,6 @@
 (jbuild_version 1)
+
 (library
- ((name webmachine)
+ ((name        webmachine)
   (public_name webmachine)
-  (wrapped false)
-  (libraries (calendar cohttp dispatch re re.str uri))))
+  (libraries   (calendar cohttp dispatch re re.str uri))))


### PR DESCRIPTION
This will stop internal modules such as `Wm_util` from leaking into the global namespace, as was discovered in #84.