### PR TITLE
choose-encoding: move choosing encoding code to Encoding module

### DIFF
--- a/lib/encoding.ml
+++ b/lib/encoding.ml
@@ -31,7 +31,7 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
-let choose ~available ~acceptable ~default =
+let choose_actual ~available ~acceptable ~default =
   let any_prio     = List.filter (fun (_, c) -> c = "*"    ) acceptable in
   let default_prio = List.filter (fun (_, c) -> c = default) acceptable in
   let default_ok =
@@ -79,7 +79,28 @@ let choose_charset ~available ~acceptable =
       q, c)
     acceptable
   in
-  choose
+  choose_actual
     ~available
     ~acceptable
     ~default:"iso-885a-1"
+;;
+
+let choose ~available ~acceptable =
+  let acceptable =
+    List.map (fun (q, c) ->
+      let c =
+        match (c : Cohttp.Accept.encoding) with
+        | AnyEncoding -> "*"
+        | Encoding e  -> e
+        | Identity    -> "identity"
+        | Gzip        -> "gzip"
+        | Compress    -> "compress"
+        | Deflate     -> "deflate"
+      in
+      q, c)
+    acceptable
+  in
+  choose_actual
+    ~available
+    ~acceptable
+    ~default:"identity"

--- a/lib/encoding.mli
+++ b/lib/encoding.mli
@@ -33,8 +33,7 @@
 
 val choose
   :  available:(string * 'a) list
-  -> acceptable:(int * string) list
-  -> default:string
+  -> acceptable:(int * Cohttp.Accept.encoding) list
   -> (string * 'a) option
 
 val choose_charset

--- a/lib/webmachine.ml
+++ b/lib/webmachine.ml
@@ -303,25 +303,11 @@ module Make(IO:IO)(Clock:CLOCK) = struct
           self#halt n
 
     method private choose_encoding acceptable k =
-      let open Accept in
-      (* Shadow the definition in Accept because it requires that you provide a
-       * quality, which should not be included *)
-      let string_of_encoding = function
-        | AnyEncoding -> "*"
-        | Encoding e  -> e
-        | Identity    -> "identity"
-        | Gzip        -> "gzip"
-        | Compress    -> "compress"
-        | Deflate     -> "deflate"
-      in
-      let acceptable =
-        List.map (fun (q, c) -> (q, string_of_encoding c)) acceptable
-      in
       resource#encodings_provided rd
       >>= function
         | Ok available, rd' ->
           rd <- rd';
-          encoding <- Encoding.choose ~available ~acceptable ~default:"identity";
+          encoding <- Encoding.choose ~available ~acceptable;
           k encoding
         | Error n, rd' ->
           rd <- rd';


### PR DESCRIPTION
The main function's already there, but move the code that's translating from the cohttp types to strings into the Encoding module as well.