### PR TITLE
adapt to dispatch 0.5.0 API changes

### DIFF
--- a/webmachine.opam
+++ b/webmachine.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ptime" {>= "0.8.0"}
   "cohttp" {>= "1.0.0"}
-  "dispatch" {>= "0.3.0" & < "0.5.0"}
+  "dispatch" {>= "0.5.0"}
   "dune" {>= "1.0"}
   "ounit" {with-test & >= "1.0.2"}
   "re" {>= "1.7.2"}


### PR DESCRIPTION
this adapts webmachine to the revised dispatch API. It would be great to have this merged, and a subsequent release of webmachine to the opam repository. thanks for reading.